### PR TITLE
Bump Flask=1.1.2 to Flask==2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.2.2
 prometheus-client==0.8.0
 PyYAML==5.4
 


### PR DESCRIPTION
- Jinja is a dependency of Flask and Flask V1.X.X uses the escape module from Jinja, however recently support for the escape module was [dropped in newer versions of Jinja](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0).

- To fix this issue, simply update to the newer version of Flask V2.X.X in your requirements.txt where Flask no longer uses the escape module from Jinja.

**Simple fix:** bump Flask=1.1.2 to Flask==2.2.2
  
```
Traceback (most recent call last):
  File "C:\Users\srim2\Documents\Personal\projects\prometheus-data-generator\prometheus_data_generator\main.py", line 9, in <module>
    from flask import Flask, Response
  File "C:\Users\srim2\Anaconda3\lib\site-packages\flask\__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (C:\Users\srim2\Anaconda3\lib\site-packages\jinja2\__init__.py)
```