### PR TITLE
updated and tested requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
-prometheus-client==0.8.0
-PyYAML==5.4
+Flask==2.3.2
+prometheus-client==0.17.1
+PyYAML==6.0.1
 


### PR DESCRIPTION
old requirements were prompting error in `pip install -r requirements.txt`. Thus tested with latest versions of requirements.

---
*PR sponsored by [Obmondo.com](https://obmondo.com)*