### PR TITLE
Add bucket support for histograms

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,3 +37,15 @@ config:
         labels:
           name: apple
           color: yellow
+
+  - name: some_histogram
+    description: some description
+    type: histogram
+    labels: [name]
+    buckets: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+    sequence:
+      - interval: 1
+        eval_time: 1
+        values: 1-5
+        labels:
+          name: apple

--- a/prometheus_data_generator/main.py
+++ b/prometheus_data_generator/main.py
@@ -9,6 +9,8 @@ import yaml
 from flask import Flask, Response
 from prometheus_client import Gauge, Counter, Summary, Histogram
 from prometheus_client import generate_latest, CollectorRegistry
+from prometheus_client.utils import INF
+
 
 
 if "PDG_LOG_LEVEL" in environ:
@@ -92,11 +94,18 @@ class PrometheusDataGenerator:
                     registry=self.registry
                 )
             elif metric["type"].lower() == "histogram":
-                # TODO add support to overwrite buckets
+                try:
+                    buckets = metric["buckets"]
+                except KeyError:
+                    buckets = [.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0]
+
+                buckets.append(INF)
+
                 instrument = Histogram(
                     metric["name"],
                     metric["description"],
                     labels,
+                    buckets=buckets,
                     registry=self.registry
                 )
             else:


### PR DESCRIPTION
Add bucket configuration for histograms. Uses prometheus default buckets by default. Add INF automatically as well.